### PR TITLE
Detectar números de teléfono con paréntesis para poderlos eliminar

### DIFF
--- a/addon/appModules/whatsapp/__init__.py
+++ b/addon/appModules/whatsapp/__init__.py
@@ -106,7 +106,7 @@ class AppModule(appModuleHandler.AppModule):
 		if getattr(obj, 'UIAAutomationId', 'BubbleListItem') != 'BubbleListItem' or not self.remove_phone_number and not self.remove_emojis:
 			return
 		if self.remove_phone_number and '+' in obj.name:
-			obj.name= sub(r'\+\d[\d\s\:\~\&-]{12,}', '', obj.name)
+			obj.name= sub(r'\+\d[\d\s\:\~\&\(\)-]{12,}', '', obj.name)
 		if self.remove_emojis:
 			obj.name= emoji.replace_emoji(obj.name, '')
 


### PR DESCRIPTION
No sé si esto antes se eliminaba correctamente o si Whatsapp ha cambiado el formato en el que muestra los números de EEUU y Canadá, pero el caso es que desde hace unos días me estaba fallando la eliminación de estos números. Este parche añade los paréntesis a los símbolos de la expresión regular que los detecta, y así ya se eliminan correctamente.